### PR TITLE
Feature add config helper

### DIFF
--- a/stompWriter.go
+++ b/stompWriter.go
@@ -2,6 +2,8 @@ package stompWriter
 
 import (
 	"net"
+	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -65,6 +67,38 @@ func New(hostname, port, username, password, queueName string) (*StompWriter, er
 	}(&newStompWriter)
 
 	return &newStompWriter, nil
+}
+
+func Configure(hostname, port, username, password, queueName, app string) (*StompWriter, error) {
+	ok := true
+	appName := strings.ToUpper(app)
+	// collect logging queue parameters
+	if hostname == "" {
+		fmt.Printf("%s_LOGQUEUEHOST not set.\n", appName)
+		ok = false
+	}
+	if port == "" {
+		fmt.Printf("%s_LOGQUEUEPORT not set.\n", appName)
+		ok = false
+	}
+	if username == "" {
+		fmt.Printf("%s_LOGQUEUEUSER not set.\n", appName)
+		ok = false
+	}
+	if password == "" {
+		fmt.Printf("%s_LOGQUEUEPASS not set.\n", appName)
+		ok = false
+	}
+	if spec.queueName == "" {
+		fmt.Printf("%s_LOGQUEUENAME not set.\n", appName)
+		ok = false
+	}
+
+	if !ok {
+		fmt.Println("Logger configurations not properly set")
+		os.Exit(1)
+	}
+	return New(hostname, port, username, password, queueName)
 }
 
 func (s *StompWriter) Connect() error {

--- a/stompWriter.go
+++ b/stompWriter.go
@@ -1,6 +1,7 @@
 package stompWriter
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -95,7 +96,9 @@ func Configure(hostname, port, username, password, queueName, app string) (*Stom
 	}
 
 	if !ok {
-		fmt.Println("Logger configurations not properly set")
+		err := errors.New("Logger configuration not properly set")
+		fmt.Println(err.Error())
+		return nil, err
 	}
 	return New(hostname, port, username, password, queueName)
 }

--- a/stompWriter.go
+++ b/stompWriter.go
@@ -1,8 +1,8 @@
 package stompWriter
 
 import (
+	"fmt"
 	"net"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -89,14 +89,13 @@ func Configure(hostname, port, username, password, queueName, app string) (*Stom
 		fmt.Printf("%s_LOGQUEUEPASS not set.\n", appName)
 		ok = false
 	}
-	if spec.queueName == "" {
+	if queueName == "" {
 		fmt.Printf("%s_LOGQUEUENAME not set.\n", appName)
 		ok = false
 	}
 
 	if !ok {
 		fmt.Println("Logger configurations not properly set")
-		os.Exit(1)
 	}
 	return New(hostname, port, username, password, queueName)
 }

--- a/stompWriter_test.go
+++ b/stompWriter_test.go
@@ -73,6 +73,17 @@ func TestStompWriter(t *testing.T) {
 
 			Expect(stompWriter.Connection).To(Equal(mockStomp))
 		})
+		g.It("should fail when configured improperly", func() {
+			hostname := ""
+			port := ""
+			username := "username"
+			password := "password"
+			queueName := "queueName"
+
+			stompWriter, err := Configure(hostname, port, username, password, queueName, "myAppName")
+			Expect(stompWriter).To(Equal((*StompWriter)(nil)))
+			Expect(err.Error()).To(Equal("dial tcp: unknown port tcp/"))
+		})
 		g.It("should send request properly", func() {
 			hostname, port, _ := net.SplitHostPort(server.URL[7:])
 			username := "username"

--- a/stompWriter_test.go
+++ b/stompWriter_test.go
@@ -75,14 +75,14 @@ func TestStompWriter(t *testing.T) {
 		})
 		g.It("should fail when configured improperly", func() {
 			hostname := ""
-			port := ""
+			port := "999"
 			username := "username"
 			password := "password"
 			queueName := "queueName"
 
 			stompWriter, err := Configure(hostname, port, username, password, queueName, "myAppName")
 			Expect(stompWriter).To(Equal((*StompWriter)(nil)))
-			Expect(err.Error()).To(Equal("dial tcp: unknown port tcp/"))
+			Expect(err.Error()).To(Equal("Logger configuration not properly set"))
 		})
 		g.It("should send request properly", func() {
 			hostname, port, _ := net.SplitHostPort(server.URL[7:])


### PR DESCRIPTION
adding a configuration helper to verify that strings aren't empty before attempting to init the stompWriter; with the aim of taking some boilerplatey stuff out of the main.go source files of the application repositories using stompWriter.

original ticket:
https://jira.monsooncommerce.com/browse/MST-2179