### PR TITLE
Feature add config helper

### DIFF
--- a/stompWriter.go
+++ b/stompWriter.go
@@ -2,6 +2,8 @@ package stompWriter
 
 import (
 	"net"
+	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -65,6 +67,38 @@ func New(hostname, port, username, password, queueName string) (*StompWriter, er
 	}(&newStompWriter)
 
 	return &newStompWriter, nil
+}
+
+func Configure(hostname, port, username, password, queueName, app string) (*StompWriter, error) {
+	ok := true
+	appName := strings.ToUpper(app)
+	// collect logging queue parameters
+	if hostname == "" {
+		fmt.Printf("%s_LOGQUEUEHOST not set.\n", appName)
+		ok = false
+	}
+	if port == "" {
+		fmt.Printf("%s_LOGQUEUEPORT not set.\n", appName)
+		ok = false
+	}
+	if username == "" {
+		fmt.Printf("%s_LOGQUEUEUSER not set.\n", appName)
+		ok = false
+	}
+	if password == "" {
+		fmt.Printf("%s_LOGQUEUEPASS not set.\n", appName)
+		ok = false
+	}
+	if spec.queueName == "" {
+		fmt.Printf("%s_LOGQUEUENAME not set.\n", appName)
+		ok = false
+	}
+
+	if !ok {
+		fmt.Println("Logger configurations not properly set")
+		os.Exit(1)
+	}
+	return New(hostname, port, username, password, queueName)
 }
 
 func (s *StompWriter) Connect() error {

--- a/stompWriter.go
+++ b/stompWriter.go
@@ -1,6 +1,7 @@
 package stompWriter
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -95,7 +96,9 @@ func Configure(hostname, port, username, password, queueName, app string) (*Stom
 	}
 
 	if !ok {
-		fmt.Println("Logger configurations not properly set")
+		err := errors.New("Logger configuration not properly set")
+		fmt.Println(err.Error())
+		return nil, err
 	}
 	return New(hostname, port, username, password, queueName)
 }

--- a/stompWriter.go
+++ b/stompWriter.go
@@ -2,12 +2,15 @@ package stompWriter
 
 import (
 	"errors"
-	"fmt"
 	"net"
 	"sync"
 	"time"
 
 	"github.com/gmallard/stompngo"
+)
+
+var (
+	BlankValueError = errors.New("Blank values in stompWriter params")
 )
 
 type stompConnectioner interface {
@@ -33,31 +36,20 @@ type StompWriter struct {
 }
 
 func New(hostname, port, username, password, queueName string) (*StompWriter, error) {
-	// collect, validate logging queue parameters
-	ok := true
 	if hostname == "" {
-		fmt.Println("StompWriter: host name not set.")
-		ok = false
+		return nil, BlankValueError
 	}
 	if port == "" {
-		fmt.Println("StompWrtier: port not set.")
-		ok = false
+		return nil, BlankValueError
 	}
 	if username == "" {
-		fmt.Println("StompWriter: username not set.")
-		ok = false
+		return nil, BlankValueError
 	}
 	if password == "" {
-		fmt.Println("StompWriter: password not set.")
-		ok = false
+		return nil, BlankValueError
 	}
 	if queueName == "" {
-		fmt.Println("StompWriter: queue name not set.")
-		ok = false
-	}
-	if !ok {
-		err := errors.New("StompWriter: configuration not properly set")
-		return nil, err
+		return nil, BlankValueError
 	}
 
 	newStompWriter := StompWriter{}

--- a/stompWriter.go
+++ b/stompWriter.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"strings"
 	"sync"
 	"time"
 
@@ -34,6 +33,33 @@ type StompWriter struct {
 }
 
 func New(hostname, port, username, password, queueName string) (*StompWriter, error) {
+	// collect, validate logging queue parameters
+	ok := true
+	if hostname == "" {
+		fmt.Println("StompWriter: host name not set.")
+		ok = false
+	}
+	if port == "" {
+		fmt.Println("StompWrtier: port not set.")
+		ok = false
+	}
+	if username == "" {
+		fmt.Println("StompWriter: username not set.")
+		ok = false
+	}
+	if password == "" {
+		fmt.Println("StompWriter: password not set.")
+		ok = false
+	}
+	if queueName == "" {
+		fmt.Println("StompWriter: queue name not set.")
+		ok = false
+	}
+	if !ok {
+		err := errors.New("StompWriter: configuration not properly set")
+		return nil, err
+	}
+
 	newStompWriter := StompWriter{}
 
 	newStompWriter.hostname = hostname
@@ -68,39 +94,6 @@ func New(hostname, port, username, password, queueName string) (*StompWriter, er
 	}(&newStompWriter)
 
 	return &newStompWriter, nil
-}
-
-func Configure(hostname, port, username, password, queueName, app string) (*StompWriter, error) {
-	ok := true
-	appName := strings.ToUpper(app)
-	// collect logging queue parameters
-	if hostname == "" {
-		fmt.Printf("%s_LOGQUEUEHOST not set.\n", appName)
-		ok = false
-	}
-	if port == "" {
-		fmt.Printf("%s_LOGQUEUEPORT not set.\n", appName)
-		ok = false
-	}
-	if username == "" {
-		fmt.Printf("%s_LOGQUEUEUSER not set.\n", appName)
-		ok = false
-	}
-	if password == "" {
-		fmt.Printf("%s_LOGQUEUEPASS not set.\n", appName)
-		ok = false
-	}
-	if queueName == "" {
-		fmt.Printf("%s_LOGQUEUENAME not set.\n", appName)
-		ok = false
-	}
-
-	if !ok {
-		err := errors.New("Logger configuration not properly set")
-		fmt.Println(err.Error())
-		return nil, err
-	}
-	return New(hostname, port, username, password, queueName)
 }
 
 func (s *StompWriter) Connect() error {

--- a/stompWriter.go
+++ b/stompWriter.go
@@ -1,8 +1,8 @@
 package stompWriter
 
 import (
+	"fmt"
 	"net"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -89,14 +89,13 @@ func Configure(hostname, port, username, password, queueName, app string) (*Stom
 		fmt.Printf("%s_LOGQUEUEPASS not set.\n", appName)
 		ok = false
 	}
-	if spec.queueName == "" {
+	if queueName == "" {
 		fmt.Printf("%s_LOGQUEUENAME not set.\n", appName)
 		ok = false
 	}
 
 	if !ok {
 		fmt.Println("Logger configurations not properly set")
-		os.Exit(1)
 	}
 	return New(hostname, port, username, password, queueName)
 }

--- a/stompWriter_test.go
+++ b/stompWriter_test.go
@@ -80,9 +80,9 @@ func TestStompWriter(t *testing.T) {
 			password := "password"
 			queueName := "queueName"
 
-			stompWriter, err := Configure(hostname, port, username, password, queueName, "myAppName")
+			stompWriter, err := New(hostname, port, username, password, queueName)
 			Expect(stompWriter).To(Equal((*StompWriter)(nil)))
-			Expect(err.Error()).To(Equal("Logger configuration not properly set"))
+			Expect(err.Error()).To(Equal("StompWriter: configuration not properly set"))
 		})
 		g.It("should send request properly", func() {
 			hostname, port, _ := net.SplitHostPort(server.URL[7:])

--- a/stompWriter_test.go
+++ b/stompWriter_test.go
@@ -82,7 +82,7 @@ func TestStompWriter(t *testing.T) {
 
 			stompWriter, err := New(hostname, port, username, password, queueName)
 			Expect(stompWriter).To(Equal((*StompWriter)(nil)))
-			Expect(err.Error()).To(Equal("StompWriter: configuration not properly set"))
+			Expect(err.Error()).To(Equal("Blank values in stompWriter params"))
 		})
 		g.It("should send request properly", func() {
 			hostname, port, _ := net.SplitHostPort(server.URL[7:])

--- a/stompWriter_test.go
+++ b/stompWriter_test.go
@@ -73,6 +73,17 @@ func TestStompWriter(t *testing.T) {
 
 			Expect(stompWriter.Connection).To(Equal(mockStomp))
 		})
+		g.It("should fail when configured improperly", func() {
+			hostname := ""
+			port := ""
+			username := "username"
+			password := "password"
+			queueName := "queueName"
+
+			stompWriter, err := Configure(hostname, port, username, password, queueName, "myAppName")
+			Expect(stompWriter).To(Equal((*StompWriter)(nil)))
+			Expect(err.Error()).To(Equal("dial tcp: unknown port tcp/"))
+		})
 		g.It("should send request properly", func() {
 			hostname, port, _ := net.SplitHostPort(server.URL[7:])
 			username := "username"

--- a/stompWriter_test.go
+++ b/stompWriter_test.go
@@ -75,14 +75,14 @@ func TestStompWriter(t *testing.T) {
 		})
 		g.It("should fail when configured improperly", func() {
 			hostname := ""
-			port := ""
+			port := "999"
 			username := "username"
 			password := "password"
 			queueName := "queueName"
 
 			stompWriter, err := Configure(hostname, port, username, password, queueName, "myAppName")
 			Expect(stompWriter).To(Equal((*StompWriter)(nil)))
-			Expect(err.Error()).To(Equal("dial tcp: unknown port tcp/"))
+			Expect(err.Error()).To(Equal("Logger configuration not properly set"))
 		})
 		g.It("should send request properly", func() {
 			hostname, port, _ := net.SplitHostPort(server.URL[7:])


### PR DESCRIPTION
this pull request adds a check for blank values in the stompWriter constructor; this will facilitate the excision of these kinds of lines from main.go:

```
	if config.LogQueueHost == "" {
		fmt.Println("APES_LOGQUEUEHOST not set.")
		ok = false
	}
	if config.LogQueuePort == "" {
		fmt.Println("APES_LOGQUEUEPORT not set.")
		ok = false
	}
	if config.LogQueueUser == "" {
		fmt.Println("APES_LOGQUEUEUSER not set.")
		ok = false
	}
	if config.LogQueuePass == "" {
		fmt.Println("APES_LOGQUEUEPASS not set.")
		ok = false
	}
	if config.LogQueueName == "" {
		fmt.Println("APES_LOGQUEUENAME not set.")
		ok = false
	}

	if !ok {
		fmt.Println("Logger configurations not properly set")
		os.Exit(1)
	}
```

revised pull request; cleaner helper less copypasta no fmt.Print statements

orig ticket:
https://jira.monsooncommerce.com/browse/MST-2179